### PR TITLE
Feature python3 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,6 @@
 omit =
     */virtualenv/*
     */venv/*
+    */.tox/*
 exclude_lines =
     if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.py~
 venv/*
+.tox/*
 build/
 dist/
 ejpcsvparser.egg-info

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -141,7 +141,8 @@ def index_table_on_article_id(table_type):
 
 @memoize
 def index_authors_on_article_id():
-    return index_table_on_article_id("authors")
+    article_index = index_table_on_article_id("authors")
+    return article_index
 
 @memoize
 def index_authors_on_author_id():

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -1,6 +1,6 @@
 import logging
 import csv
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import ejpcsvparser.utils as utils
 import ejpcsvparser.settings as settings
 
@@ -22,10 +22,10 @@ logger.setLevel(logging.INFO)
 
 def memoize(f):
     "Memoization decorator for functions taking one or more arguments."
-    class Memodict(dict):
+    class Memodict(OrderedDict):
         "Memoization dict"
         def __init__(self, f):
-            dict.__init__(self)
+            OrderedDict.__init__(self)
             self.f = f
         def __call__(self, *args):
             return self[args]
@@ -152,7 +152,7 @@ def index_authors_on_author_id():
     author_table = index_authors_on_article_id()
 
     article_ids = author_table.keys()
-    article_author_index = {}  # this is the key item we will return our of this function
+    article_author_index = OrderedDict()  # this is the key item we will return our of this function
     for article_id in article_ids:
         rows = author_table[article_id]
         author_index = defaultdict()
@@ -428,7 +428,7 @@ def index_funding_table():
     # logger.info("data_rows: " + str(data_rows))
     logger.info("col_names: " + str(col_names))
 
-    article_index = {}
+    article_index = OrderedDict()
     for data_row in data_rows:
         article_id = get_cell_value('poa_m_ms_no', col_names, data_row)
         author_id = get_cell_value(COLUMN_HEADINGS["author_id"], col_names, data_row)
@@ -436,9 +436,9 @@ def index_funding_table():
 
         # Crude multidimentional dict builder
         if article_id not in article_index:
-            article_index[article_id] = {}
+            article_index[article_id] = OrderedDict()
         if author_id not in article_index[article_id]:
-            article_index[article_id][author_id] = {}
+            article_index[article_id][author_id] = OrderedDict()
 
         article_index[article_id][author_id][funder_position] = data_row
 

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -87,13 +87,15 @@ def get_csv_sheet(table_type):
     logger.info("in get_csv_sheet")
     path = get_csv_path(table_type)
     logger.info(str(path))
-    csvreader = csv.reader(open(path, 'rb'), delimiter=',', quotechar='"')
-    sheet = []
-    for row in csvreader:
-        sheet.append(row)
+    with open(path) as csvfile:
+        csvreader = csv.reader(csvfile, delimiter=',', quotechar='"')
+        sheet = []
+        for row in csvreader:
+            sheet.append(row)
     # For overflow file types, parse again with no quotechar
     if table_type in OVERFLOW_CSV_FILES:
-        csvreader = csv.reader(open(path, 'rb'), delimiter=',', quotechar=None)
+        csvfile = open(path)
+        csvreader = csv.reader(csvfile, delimiter=',', quotechar=None)
         if table_type == "ethics":
             join_cells_from = 3
         else:
@@ -107,6 +109,7 @@ def get_csv_sheet(table_type):
                 # Strip leading quotation marks
                 row[index] = cell.lstrip('"').rstrip('"')
             sheet[csvreader.line_num-1] = row
+        csvfile.close()
     return sheet
 
 

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -134,8 +134,7 @@ def index_table_on_article_id(table_type):
     for data_row in data_rows:
         article_id = get_cell_value('poa_m_ms_no', col_names, data_row)
         # author_id = get_cell_value("poa_a_id", col_names, data_row)
-        if article_id and article_id.strip() != '':
-            article_index[article_id].append(data_row)
+        article_index[article_id].append(data_row)
         # print article_id, author_id
     return article_index
 

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -134,7 +134,8 @@ def index_table_on_article_id(table_type):
     for data_row in data_rows:
         article_id = get_cell_value('poa_m_ms_no', col_names, data_row)
         # author_id = get_cell_value("poa_a_id", col_names, data_row)
-        article_index[article_id].append(data_row)
+        if article_id and article_id.strip() != '':
+            article_index[article_id].append(data_row)
         # print article_id, author_id
     return article_index
 

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -313,6 +313,12 @@ def get_author_ids(article_id):
 
 def get_author_attribute(article_id, author_id, attribute_name):
     article_author_index = index_authors_on_author_id()
+    # check for if the data row exists first
+    if article_id not in article_author_index:
+        return None
+    if author_id not in article_author_index[article_id]:
+        return None
+    # continue
     data_row = article_author_index[article_id][author_id]
     col_names = get_csv_col_names("authors")
     attribute = get_cell_value(attribute_name, col_names, data_row)

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -22,10 +22,10 @@ logger.setLevel(logging.INFO)
 
 def memoize(f):
     "Memoization decorator for functions taking one or more arguments."
-    class Memodict(OrderedDict):
+    class Memodict(dict):
         "Memoization dict"
         def __init__(self, f):
-            OrderedDict.__init__(self)
+            dict.__init__(self)
             self.f = f
         def __call__(self, *args):
             return self[args]

--- a/ejpcsvparser/parse.py
+++ b/ejpcsvparser/parse.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from collections import OrderedDict
 from xml.dom import minidom
 from elifearticle import article as ea
 from elifetools import utils as etoolsutils
@@ -58,7 +59,7 @@ def set_article_type(article, article_id):
         article_type_id = data.get_article_type(article_id)
 
         # Boilerplate article-type values based on id in CSV file
-        article_type_index = {}
+        article_type_index = OrderedDict()
 
         article_type_index['1'] = {
             'article_type':    'research-article',
@@ -350,7 +351,7 @@ def set_funding(article, article_id):
         funder_ids = data.get_funding_ids(article_id)
 
         # Keep track of funding awards by position in a dict
-        funding_awards = {}
+        funding_awards = OrderedDict()
 
         # First pass, build the funding awards
         for (article_id, author_id, funder_position) in funder_ids:
@@ -483,7 +484,7 @@ def parse_group_authors(group_authors):
     If not empty, remove extra numbers from the end of the string
     Return a dictionary of dict[author_position] = collab_name
     """
-    group_author_dict = {}
+    group_author_dict = OrderedDict()
     if not group_authors:
         group_author_dict = None
     elif group_authors.strip() == "" or group_authors.strip() == "0":

--- a/ejpcsvparser/parse.py
+++ b/ejpcsvparser/parse.py
@@ -223,8 +223,14 @@ def set_author_info(article, article_id):
     """
     logger.info("in set_author_info")
     authors_dict = {}
+
+    # check there are any authors before continuing
+    author_ids = data.get_author_ids(article_id)
+    if not author_ids and not data.get_group_authors(article_id):
+        logger.error("could not find any author data")
+        return False
+
     try:
-        author_ids = data.get_author_ids(article_id)
         for author_id in author_ids:
 
             author_type = "author"

--- a/ejpcsvparser/utils.py
+++ b/ejpcsvparser/utils.py
@@ -24,7 +24,7 @@ def allowed_tags():
 def repl(match):
     # Convert hex to int to unicode character
     chr_code = int(match.group(1), 16)
-    return unichr(chr_code)
+    return eautils.uni_chr(chr_code)
 
 
 def entity_to_unicode(string):
@@ -67,6 +67,7 @@ def decode_brackets(string):
     Decode angle bracket escape sequence
     used to encode XML content
     """
+    string = eautils.unicode_value(string)
     string = string.replace(settings.LESS_THAN_ESCAPE_SEQUENCE, '<')
     string = string.replace(settings.GREATER_THAN_ESCAPE_SEQUENCE, '>')
     return string
@@ -84,7 +85,7 @@ def convert_to_xml_string(string):
     issue a set of conversion functions to prepare it prior
     to adding it to an article object
     """
-    string = entity_to_unicode(string).encode('utf-8')
+    string = entity_to_unicode(string)
     string = decode_brackets(string)
     string = eautils.replace_tags(string, 'i', 'italic')
     string = eautils.replace_tags(string, 'u', 'underline')

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-set -e
 
-virtualenv venv
-source venv/bin/activate
-pip install -r requirements.txt
+tox
+. .tox/py35/bin/activate
 pip install coveralls
-coverage run -m unittest discover tests
 COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/ejp-csv-parser) coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-git+https://github.com/elifesciences/elife-tools.git@52827ded2d434d2f255f287d5bebeba3ccb9a805#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@2b4e261579a8905ed02181bd96ccbcbb55850606#egg=elifearticle
+git+https://github.com/elifesciences/elife-tools.git@352226be98e6adec488406268acb50a9b76876db#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@e83828ab496a66bacd713879f5ee9c35eceeeb7c#egg=elifearticle
 GitPython==2.1.7
 configparser==3.5.0
 mock==1.3.0
+coverage==4.4.2

--- a/tests/test_csv_data.py
+++ b/tests/test_csv_data.py
@@ -286,7 +286,7 @@ class TestCsvData(unittest.TestCase):
     def test_index_funding_table(self):
         article_index = data.index_funding_table()
         self.assertIsNotNone(article_index)
-        self.assertEqual(article_index.keys(), ['7', '12717', '14874', '14997', '21598'])
+        self.assertEqual(list(article_index.keys()), ['7', '12717', '14874', '14997', '21598'])
 
     def test_get_funding_ids(self):
         article_id = '12717'

--- a/tests/test_csv_data.py
+++ b/tests/test_csv_data.py
@@ -41,11 +41,13 @@ class TestCsvData(unittest.TestCase):
 
     def test_index_authors_on_article_id(self):
         expected_row_count = 9
-        self.assertEqual(len(data.index_authors_on_article_id()), expected_row_count)
+        article_index = data.index_authors_on_article_id()
+        self.assertEqual(len(article_index), expected_row_count)
 
     def test_index_authors_on_author_id(self):
         expected_row_count = 9
-        self.assertEqual(len(data.index_authors_on_author_id()), expected_row_count)
+        article_author_index = data.index_authors_on_author_id()
+        self.assertEqual(len(article_author_index), expected_row_count)
 
     def test_get_article_attributes(self):
         article_id = 3

--- a/tests/test_csv_data.py
+++ b/tests/test_csv_data.py
@@ -286,7 +286,7 @@ class TestCsvData(unittest.TestCase):
     def test_index_funding_table(self):
         article_index = data.index_funding_table()
         self.assertIsNotNone(article_index)
-        self.assertEqual(article_index.keys(), ['21598', '14874', '12717', '7', '14997'])
+        self.assertEqual(article_index.keys(), ['7', '12717', '14874', '14997', '21598'])
 
     def test_get_funding_ids(self):
         article_id = '12717'

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -341,10 +341,10 @@ class TestParse(unittest.TestCase):
         self.assertEqual(contrib.given_name, None)
         self.assertEqual(contrib.collab, 'ICGC Breast Cancer Group')
 
-        # test not finding a value, currently still returns True
+        # test not finding a value
         article = Article()
         return_value = parse.set_author_info(article, '99999')
-        self.assertTrue(return_value)
+        self.assertFalse(return_value)
 
 
     @patch('ejpcsvparser.csv_data.get_author_ids')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+skipsdist = True
+envlist = py27,py35
+[testenv]
+deps = -rrequirements.txt
+commands = coverage run -m unittest discover tests


### PR DESCRIPTION
Changes to make this library compatible with both Python 2.7 and Python 3.5, using tox for testing.

I think most of the changes were to use ``OrderedDict()`` in places where a plain ``dict`` was used so the test output was predictable.

The csv library under Python 3 complained a bit so I changed that.

A couple little encoding changes.

The test cases themselves changed very little, just ordering the keys of a list in order to do a test assertion.