### PR TITLE
Funding character entity change

### DIFF
--- a/tests/test_data/poa_funding.csv
+++ b/tests/test_data/poa_funding.csv
@@ -2,7 +2,7 @@
 "Generated on May 20, 2016"
 
 "poa_m_ms_id","poa_m_ms_no","poa_a_id","poa_grant_ref_no","poa_funder_order","poa_funder","poa_fund_ref_id"
-"15","7","1399"," ","1","CHF | The Cöffee H&#x00F8;use Foundation (Forskningsr&#x00E5;det)"," "
+"15","7","1399"," ","1","CHF | The C&#x00F6;ffee H&#x00F8;use Foundation (Forskningsr&#x00E5;det)"," "
 "18022","12717","13727","1R01NS066936","1","HHS | NIH | National Institute of Neurological Disorders and Stroke (NINDS)","100000065"
 "18022","12717","13727","#1-FY12-455","2","March of Dimes Foundation (March of Dimes)","100000912"
 "21090","14874","6967","GM106105, GM107465, GM62580","1","HHS | National Institutes of Health (NIH)","100000002"


### PR DESCRIPTION
In poa_funding.csv test data use entity &#x00F6; instead of o-umlaut.