### PR TITLE
Clean csv tweak

### DIFF
--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -138,7 +138,7 @@ def flatten_lines(iterable, data_start_row=DATA_START_ROW):
 def clean_csv(path):
     "fix CSV file oddities making it difficult to parse"
     clean_csv_data = u''
-    new_path = os.path.join(settings.TMP_DIR, path.split('/')[-1])
+    new_path = os.path.join(TMP_DIR, os.path.split(path)[-1])
     with open(path, 'r') as open_read_file:
         clean_csv_data = flatten_lines(open_read_file)
     with open(new_path, 'w') as open_write_file:

--- a/ejpcsvparser/utils.py
+++ b/ejpcsvparser/utils.py
@@ -185,7 +185,7 @@ def decode_cp1252(string):
         # Wrap the decode in another exception to make sure this never fails
         try:
             string = string.decode('cp1252')
-        except (UnicodeEncodeError, UnicodeDecodeError):
+        except (UnicodeEncodeError, UnicodeDecodeError, AttributeError):
             pass
     return string
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -273,9 +273,9 @@ class TestParseEthics(unittest.TestCase):
 
     def test_parse_ethics(self):
         "test examples of parsing ethics data"
-        with open(fixture_path('ethic_data.txt'), 'rb') as open_file:
+        with open(fixture_path('ethic_data.txt'), 'r') as open_file:
             ethic = open_file.read()
-        with open(fixture_path('ethic_expected_0.txt'), 'rb') as open_file:
+        with open(fixture_path('ethic_expected_0.txt'), 'r') as open_file:
             expected = open_file.read()
         parse_status, ethics = parse.parse_ethics(ethic)
         self.assertTrue(parse_status)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -273,9 +273,9 @@ class TestParseEthics(unittest.TestCase):
 
     def test_parse_ethics(self):
         "test examples of parsing ethics data"
-        with open(fixture_path('ethic_data.txt'), 'r') as open_file:
+        with open(fixture_path('ethic_data.txt')) as open_file:
             ethic = open_file.read()
-        with open(fixture_path('ethic_expected_0.txt'), 'r') as open_file:
+        with open(fixture_path('ethic_expected_0.txt')) as open_file:
             expected = open_file.read()
         parse_status, ethics = parse.parse_ethics(ethic)
         self.assertTrue(parse_status)


### PR DESCRIPTION
Small changes as I continue integrating it with the bot activity, this makes it easier to override where the CSV data is loaded from, better cross-platform paths, and an encoding thing for python 2 and 3 support.