### PR TITLE
Author affiliation fix

### DIFF
--- a/ejpcsvparser/parse.py
+++ b/ejpcsvparser/parse.py
@@ -258,7 +258,6 @@ def set_author_info(article, article_id):
             author = build_author(article_id, author_id, author_type)
 
             affiliation = author_affiliation(article_id, author_id)
-            author.set_affiliation(affiliation)
             # set corresponding if the affiliation has an email
             if affiliation.email:
                 author.corresp = True

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -421,6 +421,8 @@ class TestParseAuthors(unittest.TestCase):
         self.assertEqual(contrib.collab, None)
         self.assertEqual(contrib.conflict, ['Senior Editor, <italic>eLife</italic>'])
         self.assertEqual(contrib.group_author_key, None)
+        # count affiliations
+        self.assertEqual(len(article.contributors[2].affiliations), 1)
         aff = article.contributors[2].affiliations[0]
         self.assertEqual(aff.phone, None)
         self.assertEqual(aff.fax, None)


### PR DESCRIPTION
Do not add author affiliation twice, and test it is only one instead of two.

Fixes a bug encountered in jats-generator in prod.