### PR TITLE
elifetools upgraded

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/elifesciences/elife-tools.git@df537e13da03accf1f4dee83c6c0892742860b07#egg=elifetools
+git+https://github.com/elifesciences/elife-tools.git@6c4f822ab8d1bed99c20da057a7907a6ad9a78ce#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@82de72418be2cfdc6d98421bfadac487208555db#egg=elifearticle
 GitPython==2.1.7
 configparser==3.5.0

--- a/tests/test_csv_data.py
+++ b/tests/test_csv_data.py
@@ -1,4 +1,5 @@
 import unittest
+from six.moves import reload_module
 from mock import patch
 from ejpcsvparser import csv_data as data
 
@@ -127,11 +128,15 @@ class TestIndexing(TestCsvData):
         self.assertEqual(len(data.get_csv_data_rows(table_type)), expected_row_count)
 
     def test_index_authors_on_article_id(self):
+        # reload module first to avoid memoize remembering data from other test scenarios
+        reload_module(data)
         expected_row_count = 9
         article_index = data.index_authors_on_article_id()
         self.assertEqual(len(article_index), expected_row_count)
 
     def test_index_authors_on_author_id(self):
+        # reload module first to avoid memoize remembering data from other test scenarios
+        reload_module(data)
         expected_row_count = 9
         article_author_index = data.index_authors_on_author_id()
         self.assertEqual(len(article_author_index), expected_row_count)


### PR DESCRIPTION
Latest `elifetools` library looks to be compatible. I tracked down errors in CSV data index counts I remember getting before and again now, solved by reloading the `csv_data` module when testing the index counts, to lose the memorized (memoize decorator) data.