### PR TITLE
Drop py27 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "2.7"
+  - "3.5"
 # command to install dependencies
 install: ./travis-install.sh
 script: ./travis-test.sh

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -154,11 +154,8 @@ def get_csv_sheet(table_type):
 
     path = clean_csv(path)
 
-    if sys.version_info[0] < 3:
-        handle = open(path, 'rb')
-    else:
-        # https://docs.python.org/3/library/functions.html#open
-        handle = io.open(path, 'r', newline='', encoding='utf-8', errors='surrogateescape')
+    # https://docs.python.org/3/library/functions.html#open
+    handle = io.open(path, 'r', newline='', encoding='utf-8', errors='surrogateescape')
 
     with handle as csvfile:
         csvreader = csv.reader(csvfile, delimiter=',', quotechar='"')

--- a/ejpcsvparser/parse.py
+++ b/ejpcsvparser/parse.py
@@ -317,7 +317,7 @@ def set_editor_info(article, article_id):
         first_name += " " + middle_name
     # create an instance of the POSContributor class
     editor = ea.Contributor(author_type, last_name, first_name)
-    LOGGER.info("editor is: %s", eautils.unicode_value(editor))
+    LOGGER.info("editor is: %s", str(editor))
     LOGGER.info("getting ed id for article %s", article_id)
     LOGGER.info("editor id is %s", data.get_me_id(article_id))
     LOGGER.info(str(type(data.get_me_id(article_id))))

--- a/ejpcsvparser/utils.py
+++ b/ejpcsvparser/utils.py
@@ -76,12 +76,6 @@ def license_data(license_id):
     return license_data
 
 
-def repl(match):
-    # Convert hex to int to unicode character
-    chr_code = int(match.group(1), 16)
-    return eautils.uni_chr(chr_code)
-
-
 def entity_to_unicode(string):
     """
     Quick convert unicode HTML entities to unicode characters
@@ -102,7 +96,7 @@ def entity_to_unicode(string):
     replacements.append((r"&rdquo;", '"'))
 
     # First, replace numeric entities with unicode
-    string = re.sub(r"&#x(....);", repl, string)
+    string = re.sub(r"&#x(....);", eautils.repl, string)
     # Second, replace some specific entities specified in the list
     for entity, replacement in replacements:
         string = re.sub(entity, replacement, string)
@@ -124,7 +118,7 @@ def decode_brackets(string):
     Decode angle bracket escape sequence
     used to encode XML content
     """
-    string = eautils.unicode_value(string)
+    string = str(string)
     string = string.replace(settings.LESS_THAN_ESCAPE_SEQUENCE, '<')
     string = string.replace(settings.GREATER_THAN_ESCAPE_SEQUENCE, '>')
     return string

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/elifesciences/elife-tools.git@6c4f822ab8d1bed99c20da057a7907a6ad9a78ce#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@82de72418be2cfdc6d98421bfadac487208555db#egg=elifearticle
+git+https://github.com/elifesciences/elife-tools.git@1ca1de40c9747a2ba25559ec5c5f52f00c1fd85e#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@158d5d9484aeb22bfb5109a79db3615f8fbe8ab0#egg=elifearticle
 GitPython==2.1.7
 configparser==3.5.0
 mock==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         ]
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py35
+envlist = py35
 [testenv]
 deps = -rrequirements.txt
 commands = coverage run -m unittest discover tests


### PR DESCRIPTION
Fixes https://github.com/elifesciences/ejp-csv-parser/issues/25

As I mentioned in the issue above, there is potentially some further refactoring that could be done, but I do not want to disrupt things as a result of trying.

This PR uses the latest `elifetools` and `elifearticle` libraries that already had their `py27` support dropped from them.