### PR TITLE
Use pytest instead of tox for project testing.

### DIFF
--- a/mkvenv.sh
+++ b/mkvenv.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+python=''
+pybinlist=("python3.8" "python3.6")
+
+for pybin in ${pybinlist[*]}; do
+    which "$pybin" &> /dev/null || continue
+    python=$pybin
+    break
+done
+
+if [ -z "$python" ]; then
+    echo "no usable python found, exiting"
+    exit 1
+fi
+
+if [ ! -e "venv/bin/$python" ]; then
+    echo "could not find venv/bin/$python, recreating venv"
+    rm -rf venv
+    $python -m venv venv
+else
+    echo "using $python"
+fi

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-
-tox
-. .tox/py3/bin/activate
-pip install coveralls
-COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/ejp-csv-parser) coveralls
+set -e
+. mkvenv.sh
+source venv/bin/activate
+pip install coveralls wheel pip pytest --upgrade
+pip install -r requirements.txt
+coverage run -m pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/elifesciences/elife-tools.git@f9ed819e137b8ec96900d8cab59f4a8c9911ce45#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@a3cc8244d3ddcb45039d8a3d876dfd4673c9975e#egg=elifearticle
+elifetools==0.11.0
+elifearticle==0.6.0
 GitPython==3.1.2
 configparser==3.5.0
 mock==1.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-skipsdist = True
-envlist = py3
-[testenv]
-deps = -rrequirements.txt
-commands = coverage run -m unittest discover tests


### PR DESCRIPTION
Prior to configuring a library release pipeline, no longer use `tox` for running tests, let's use `pytest` directly.