### PR TITLE
Log to null handler by default, optional log file.

### DIFF
--- a/ejpcsvparser/__init__.py
+++ b/ejpcsvparser/__init__.py
@@ -1,1 +1,18 @@
-__version__ = "0.1.2"
+import logging
+
+__version__ = "0.2.0"
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.addHandler(logging.NullHandler())
+
+
+def configure_logging(filename, level=logging.INFO, format_string=None):
+    "configure logging to file"
+    if not format_string:
+        format_string = "%(asctime)s %(levelname)s %(name)s:%(module)s:%(funcName)s: %(message)s"
+    handler = logging.FileHandler(filename)
+    formatter = logging.Formatter(format_string)
+    handler.setFormatter(formatter)
+    LOGGER.addHandler(handler)
+    LOGGER.setLevel(level)
+    return handler

--- a/ejpcsvparser/csv_data.py
+++ b/ejpcsvparser/csv_data.py
@@ -3,7 +3,7 @@ import csv
 import io
 import os
 from collections import defaultdict, OrderedDict
-from ejpcsvparser import settings, utils
+from ejpcsvparser import LOGGER, settings, utils
 
 
 # todo!! clean up these values and the settings
@@ -14,13 +14,6 @@ DATA_START_ROW = settings.DATA_START_ROW
 CSV_FILES = settings.CSV_FILES
 COLUMN_HEADINGS = settings.CSV_COLUMN_HEADINGS
 OVERFLOW_CSV_FILES = settings.OVERFLOW_CSV_FILES
-
-LOGGER = logging.getLogger("csv_data")
-HDLR = logging.FileHandler("csv_data.log")
-FORMATTER = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-HDLR.setFormatter(FORMATTER)
-LOGGER.addHandler(HDLR)
-LOGGER.setLevel(logging.INFO)
 
 
 def memoize(value):

--- a/ejpcsvparser/parse.py
+++ b/ejpcsvparser/parse.py
@@ -7,15 +7,8 @@ from xml.parsers.expat import ExpatError
 from elifearticle import article as ea
 from elifearticle import utils as eautils
 from elifetools import utils as etoolsutils
-from ejpcsvparser import utils
+from ejpcsvparser import LOGGER, utils
 import ejpcsvparser.csv_data as data
-
-LOGGER = logging.getLogger("parse")
-HDLR = logging.FileHandler("parse.log")
-FORMATTER = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-HDLR.setFormatter(FORMATTER)
-LOGGER.addHandler(HDLR)
-LOGGER.setLevel(logging.INFO)
 
 
 def instantiate_article(article_id):

--- a/tests/test_csv_data.py
+++ b/tests/test_csv_data.py
@@ -1,6 +1,8 @@
 import unittest
+import os
 from six.moves import reload_module
 from mock import patch
+from ejpcsvparser import configure_logging
 from ejpcsvparser import csv_data as data
 
 from tests import csv_test_settings
@@ -110,6 +112,15 @@ class TestCleanCsv(TestCsvData):
 
 
 class TestIndexing(TestCsvData):
+    def setUp(self):
+        # configure logging
+        self.log_filename = "tests/tmp/csv_data.log"
+        configure_logging(self.log_filename)
+
+    def tearDown(self):
+        # remve the log file
+        os.remove(self.log_filename)
+
     def test_get_csv_path(self):
         path_type = "authors"
         expected = "tests/test_data/poa_author.csv"
@@ -124,6 +135,12 @@ class TestIndexing(TestCsvData):
             "poa_l_license_dt",
         ]
         self.assertEqual(data.get_csv_col_names(table_type), expected)
+        # check for log file contents
+        with open(self.log_filename, "r", encoding="utf-8") as open_file:
+            self.assertTrue(
+                "INFO ejpcsvparser:csv_data:get_csv_sheet: tests/test_data/poa_license.csv"
+                in open_file.read()
+            )
 
     def test_get_csv_data_rows(self):
         table_type = "authors"


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/7771

When using this library, by default it is logging lots of data to a log file at the `INFO` level.

Logging to a null handler will be the default now, and by invoking `configure_logging()` a log file can be configured if wanted.