### PR TITLE
Dependency elifearticle>=0.16.0

### DIFF
--- a/ejpcsvparser/__init__.py
+++ b/ejpcsvparser/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=["ejpcsvparser"],
     license="MIT",
     install_requires=[
-        "elifearticle>=0.17.0",
+        "elifearticle>=0.16.0",
         "elifetools>=0.33.0",
         "GitPython",
         "configparser",


### PR DESCRIPTION
The code changes are still compatible with `elifearticle==0.16.0` and it will help with releasing in other projects.